### PR TITLE
Fix empty CodeQL results

### DIFF
--- a/sast-fuzz/static_analysis/sast/config.yml
+++ b/sast-fuzz/static_analysis/sast/config.yml
@@ -258,6 +258,9 @@ tools:
       - '%LIBRARY_PATH%/cpp/ql/src/Security/CWE/CWE-764/UnreleasedLock.ql'
       - '%LIBRARY_PATH%/cpp/ql/src/Security/CWE/CWE-807/TaintedCondition.ql'
       - '%LIBRARY_PATH%/cpp/ql/src/Security/CWE/CWE-835/InfiniteLoopWithUnsatisfiableExitCondition.ql'
+      # not actually security queries, but metrics for sanity checking:
+      - '%LIBRARY_PATH%/cpp/ql/src/Summary/LinesOfCode.ql'
+      - '%LIBRARY_PATH%/cpp/ql/src/Summary/LinesOfUserCode.ql'
     num_threads: 8
   clang_scan:
     path: '/opt/llvm-12.0.0/build/bin/scan-build'


### PR DESCRIPTION
CodeQL returned empty result files on many of the projects I tested it on. This might be related to out-of-source builds, as usually performed by cmake.
It turned out that during database creation, it correctly reads the source files, but does not consider the code user-written. This fix adds a check for this condition.
Furthermore, it (hopefully) fixes the root cause by letting codeql call the user-provided build script instead of having it the other way around.

Things you may want to check:
- Are the logging levels I used for the regression check consistent with your logging policy?
- The code formatting check currently fails, but I didn't touch that file. It seems like black and isort contradict there 😅 