### PR TITLE
Fix for out_of_range error when accessing targetIndices with a non-targeted bb due to a cascading problem in distance

### DIFF
--- a/sast-fuzz/code_instrumentation/target_sites/src/main.cpp
+++ b/sast-fuzz/code_instrumentation/target_sites/src/main.cpp
@@ -523,7 +523,14 @@ void instrument(const TargetInfos &targetInfos) {
             if (dTb.count(bb)) {
                 uint32_t bbId = allBBIndices.at(bb);
 
-                auto distance = (uint32_t)(100 * dTb[bb]);
+                /* Ensure distance is not zero for non-target basic blocks */
+                double rawDistance = 100.0 * dTb[bb];
+                uint32_t distance;
+                if (rawDistance < 1.0 && rawDistance > 0.0) {
+                    distance = 1;
+                } else {
+                    distance = (uint32_t)(rawDistance);
+                }
 
                 ConstantInt *Distance = ConstantInt::get(LargestType, (unsigned)distance);
 


### PR DESCRIPTION
This fixes handling of the issue mentioned in #28. 

If you want to make it shorter but sacrifice a bit of readability, we could go with the code below as well.

```c
uint32_t distance = (rawDistance > 0.0 && rawDistance < 1.0) ? 1 : (uint32_t)(rawDistance);
```

Please let me know your thoughts.